### PR TITLE
Removing meta-data-v2 extension

### DIFF
--- a/variables/development.yml
+++ b/variables/development.yml
@@ -5,8 +5,8 @@ web_vm_type: production-concourse-web
 worker_vm_type: production-concourse-worker
 iaas_worker_vm_type: production-concourse-iaas-worker
 web_vm_extensions: [production-concourse-lb]
-worker_vm_extensions: [production-concourse-profile, meta-data-v2]
-iaas_worker_vm_extensions: [production-concourse-iaas-profile, meta-data-v2]
+worker_vm_extensions: [production-concourse-profile]
+iaas_worker_vm_extensions: [production-concourse-iaas-profile]
 network_name: production-concourse
 web_instances: 1
 worker_instances: 2

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -5,8 +5,8 @@ web_vm_type: m6i.large.concourse.web
 worker_vm_type: m6i.xlarge.concourse.worker
 iaas_worker_vm_type: m6i.xlarge.concourse.worker
 web_vm_extensions: [production-concourse-lb]
-worker_vm_extensions: [production-concourse-profile, meta-data-v2]
-iaas_worker_vm_extensions: [production-concourse-iaas-profile, meta-data-v2]
+worker_vm_extensions: [production-concourse-profile]
+iaas_worker_vm_extensions: [production-concourse-iaas-profile]
 network_name: production-concourse
 web_instances: 2
 worker_instances: 10

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -6,8 +6,8 @@ web_vm_type: t3.medium.concourse.web
 worker_vm_type: m5.xlarge.concourse.worker
 iaas_worker_vm_type: m5.xlarge.concourse.worker
 web_vm_extensions: [staging-concourse-lb]
-worker_vm_extensions: [staging-concourse-profile, meta-data-v2]
-iaas_worker_vm_extensions: [staging-concourse-iaas-profile, meta-data-v2]
+worker_vm_extensions: [staging-concourse-profile]
+iaas_worker_vm_extensions: [staging-concourse-iaas-profile]
 network_name: staging-concourse
 web_instances: 1
 worker_instances: 2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the usage of the `meta-data-v2` cloud config vm_extension, this is now configured globally in the BOSH CPI with https://github.com/cloud-gov/deploy-bosh/pull/625
- Part of https://github.com/cloud-gov/private/issues/1911

## security considerations
Continues the use of a token to access metadata information
