### PR TITLE
remove docker-registry-mirror and add defaults

### DIFF
--- a/operations/base-resource-defaults.yml
+++ b/operations/base-resource-defaults.yml
@@ -2,7 +2,8 @@
   path: /instance_groups/name=web/jobs/name=web/properties/base_resource_type_defaults?
   value: >
     registry-image:
-      registry_mirror:
-        host: ((docker-registry-mirror))
-    docker-image:
-      registry_mirror: https://((docker-registry-mirror))
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the docker-registry-mirror since we no longer need it after moving to hardened images
- Adds defaults for registry-image so that we don't have to set them in every pipeline anymore

## security considerations
Removing docker-registry-mirror
