### PR TITLE
Convert m5 to m6i

### DIFF
--- a/operations/production-disk-size.yml
+++ b/operations/production-disk-size.yml
@@ -1,11 +1,11 @@
 # worker
 - type: replace
-  path: /vm_types/name=m5.xlarge/cloud_properties/ephemeral_disk?/size?
+  path: /vm_types/name=m6i.xlarge/cloud_properties/ephemeral_disk?/size?
   value: 300_000
 
 # iaas worker
 - type: replace
-  path: /vm_types/name=m5.xlarge/cloud_properties/ephemeral_disk?/size?
+  path: /vm_types/name=m6i.xlarge/cloud_properties/ephemeral_disk?/size?
   value: 300_000
 
 # web

--- a/operations/staging-disk-size.yml
+++ b/operations/staging-disk-size.yml
@@ -1,11 +1,11 @@
 # worker
 - type: replace
-  path: /vm_types/name=m5.large/cloud_properties/ephemeral_disk?/size?
+  path: /vm_types/name=m6i.large/cloud_properties/ephemeral_disk?/size?
   value: 300_000
 
 # iaas worker
 - type: replace
-  path: /vm_types/name=m5.large/cloud_properties/ephemeral_disk?/size?
+  path: /vm_types/name=m6i.large/cloud_properties/ephemeral_disk?/size?
   value: 300_000
 
 # web

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -3,8 +3,8 @@ external_url: https://ci.fr-stage.cloud.gov
 credhub_url: https://credhub.fr-stage.cloud.gov
 azs: [z2]
 web_vm_type: t3.medium.concourse.web
-worker_vm_type: m5.xlarge.concourse.worker
-iaas_worker_vm_type: m5.xlarge.concourse.worker
+worker_vm_type: m6i.xlarge.concourse.worker
+iaas_worker_vm_type: m6i.xlarge.concourse.worker
 web_vm_extensions: [staging-concourse-lb]
 worker_vm_extensions: [staging-concourse-profile]
 iaas_worker_vm_extensions: [staging-concourse-iaas-profile]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove m5 usage, discovered during AWS pricing session
- https://github.com/cloud-gov/private/issues/618
-

## security considerations
None, just changing vm instance classes