### PR TITLE
update smoke-test

### DIFF
--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -14,7 +14,7 @@ chmod +x ./fly
 )
 
 
-# be sure the registry-image type works through the mirror config
+# be sure the registry-image type works
 cat > registry-image-config.yml << EOF
 platform: linux
 

--- a/ci/smoke-test.sh
+++ b/ci/smoke-test.sh
@@ -13,26 +13,6 @@ chmod +x ./fly
     --password "${BASIC_AUTH_PASSWORD}"
 )
 
-# be sure the docker-image type works through the mirror config
-cat > docker-image-config.yml << EOF
-platform: linux
-
-image_resource:
-  type: docker-image
-  source:
-    repository: busybox
-
-run:
-  path: echo
-  args: ["smoke"]
-EOF
-
-output=$(./fly --target ci execute --config ./docker-image-config.yml)
-
-if ! echo "${output}" | grep smoke; then
-  echo "Expected to find 'smoke' in output"
-  exit 1
-fi
 
 # be sure the registry-image type works through the mirror config
 cat > registry-image-config.yml << EOF
@@ -41,7 +21,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: busybox
+    repository: general-task
 
 run:
   path: echo


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update smoke-test to no longer check the docker-image type
- Update the registry-image type check to use our general-task image

## security considerations
Updating smoke tests for removal of docker registry mirror
