### PR TITLE
Testing whether this extends jumpbox timeout to 30m

### DIFF
--- a/operations/compliance.yml
+++ b/operations/compliance.yml
@@ -4,4 +4,4 @@
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/intercept_idle_timeout?
-  value: 10m
+  value: 30m


### PR DESCRIPTION
## Changes proposed in this pull request:
- Attempting to make jumpbox timeout 30 minutes instead of 10 minutes.  Why?  Reducing stress on the admins and a bit less angst against Concourse :) 
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Did not find anything is SSP regarding 10 minute limit for jumpboxes.
